### PR TITLE
focus 시 class가 Object로 들어가는 문제 수정

### DIFF
--- a/src/components/atoms/TextField/TextField.styles.ts
+++ b/src/components/atoms/TextField/TextField.styles.ts
@@ -35,9 +35,7 @@ export const textFieldVariants = tv({
   ],
   variants: {
     focus: {
-      true: [
-        "interactionFocus:opacity-0, interactionFocusVisible:opacity-0, focus-within:border-none, focus-visible:border-none",
-      ],
+      true: "interactionFocus:opacity-0, interactionFocusVisible:opacity-0, focus-within:border-none, focus-visible:border-none",
     },
     error: {
       true: ["bg-error-container", "border-error", "!outline-error", "font-bold"],


### PR DESCRIPTION
ISSUES CLOSED: #21

## PR 종류

어떤 타입의 Pull Request인가요?

- [x] 버그 픽스
- [ ] 기능 추가
- [ ] CSS 변경
- [ ] 코드 스타일 변경(포맷팅, 지역 변수 등)
- [ ] 리팩토링(기능 변경 X, API 변경 X)
- [ ] 환경 설정 관련 변경
- [ ] 문서 수정
- [ ] 기타... : 설명해주세요.

## 현재는 어떻게 동작하나요?

TextField에서 focus용 class가 object Object로 들어감

이슈 번호: #21 

## PR이 적용된다면 어떻게 동작하나요?

TextField의 focus용 class가 정상적으로 들어감.
focus 시 정상 표시

![image](https://github.com/bh2980/chistock-ui/assets/74360958/f0224dfc-31a4-4c36-8d4c-c502ba81ed53)



## 기타 정보
